### PR TITLE
Add basic firewall group and rulesets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ terraform/.terraform
 terraform/.terraform.lock.hcl
 terraform/terraform.tfstate
 terraform/terraform.tfstate.backup
-terraform/terraform.tfvars
+terraform/variables.tfvars
+terraform/variables.auto.tfvars

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -17,13 +17,37 @@ resource "vultr_instance" "terrariaform-server" {
   region = var.region
   os_id = var.os
   script_id = vultr_startup_script.terrariaform-startup-script.id
+  firewall_group_id = vultr_firewall_group.terrariaform-firewall.id 
   ssh_key_ids = [vultr_ssh_key.terrariaform_ssh_key.id]
+
 }
 
 resource "vultr_startup_script" "terrariaform-startup-script" {
   name        = "terrariaform-startup-script"
   script      = base64encode(file("../scripts/startup.sh"))
   type        = "boot"
+}
+
+resource "vultr_firewall_group" "terrariaform-firewall" {
+  description = "Base firewall group for Terrariaform"
+}
+
+resource "vultr_firewall_rule" "terrariaform-firewall-rule" {
+  firewall_group_id = vultr_firewall_group.terrariaform-firewall.id
+  protocol          = "tcp"
+  port              = "7777"
+  subnet = "0.0.0.0"
+  subnet_size = 0
+  ip_type = "v4"
+}
+
+resource "vultr_firewall_rule" "terrariaform-firewall-rule-ssh" {
+  firewall_group_id = vultr_firewall_group.terrariaform-firewall.id
+  protocol          = "tcp"
+  port              = "22"
+  subnet = "0.0.0.0"
+  subnet_size = 0
+  ip_type = "v4"
 }
 
 resource "vultr_ssh_key" "terrariaform_ssh_key" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,17 +11,6 @@ provider "vultr" {
   api_key = var.api_key
 }
 
-resource "vultr_ssh_key" "terrariaform_ssh_key" {
-  name    = "terrariaform-key"
-  ssh_key = var.public_ssh_key
-}
-
-resource "vultr_startup_script" "terrariaform-startup-script" {
-  name        = "terrariaform-startup-script"
-  script      = base64encode(file("../scripts/startup.sh"))
-  type        = "boot"
-}
-
 resource "vultr_instance" "terrariaform-server" {
   label = "terrariaform-server"
   plan = var.instance
@@ -30,3 +19,17 @@ resource "vultr_instance" "terrariaform-server" {
   script_id = vultr_startup_script.terrariaform-startup-script.id
   ssh_key_ids = [vultr_ssh_key.terrariaform_ssh_key.id]
 }
+
+resource "vultr_startup_script" "terrariaform-startup-script" {
+  name        = "terrariaform-startup-script"
+  script      = base64encode(file("../scripts/startup.sh"))
+  type        = "boot"
+}
+
+resource "vultr_ssh_key" "terrariaform_ssh_key" {
+  name    = "terrariaform-key"
+  ssh_key = var.public_ssh_key
+}
+
+
+

--- a/terraform/variables.example.tfvars
+++ b/terraform/variables.example.tfvars
@@ -1,0 +1,5 @@
+api_key =
+instance =
+os =
+region = 
+public_ssh_key = 


### PR DESCRIPTION
This pull request introduces significant updates to the Terraform configuration for deploying a Vultr-based Terraria server. The changes include restructuring resources, adding a firewall configuration, and improving modularity by defining example variables for user customization.

### Resource restructuring and enhancements:
* Replaced the `vultr_ssh_key` resource with a `vultr_instance` resource to define the Terraria server instance, including attributes like `plan`, `region`, `os_id`, and dependencies on startup scripts, firewall groups, and SSH keys. (`terraform/main.tf`, [terraform/main.tfL14-R22](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028L14-R22))
* Added a `vultr_firewall_group` resource to create a base firewall group and two `vultr_firewall_rule` resources to allow traffic on Terraria's default port (7777) and SSH (port 22). (`terraform/main.tf`, [terraform/main.tfL25-R59](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028L25-R59))

### Modularization:
* Introduced a `terraform/variables.example.tfvars` file to provide example variable definitions for `api_key`, `instance`, `os`, `region`, and `public_ssh_key`, making the configuration more user-friendly and customizable. (`terraform/variables.example.tfvars`, [terraform/variables.example.tfvarsR1-R5](diffhunk://#diff-49de6eb504fb2aae73d10821558267c1f2095b94f9b2ae0ce51ad038aa7c5dfeR1-R5))