### PR TITLE
Ensure container is restart when instance is restarted

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   tmodloader:
     image: 'jacobsmile/tmodloader1.4:latest'
     container_name: 'tmodloader'
+    restart: unless-stopped
     ports:
       - "7777:7777"
     expose:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,7 +19,6 @@ resource "vultr_instance" "terrariaform-server" {
   script_id = vultr_startup_script.terrariaform-startup-script.id
   firewall_group_id = vultr_firewall_group.terrariaform-firewall.id 
   ssh_key_ids = [vultr_ssh_key.terrariaform_ssh_key.id]
-
 }
 
 resource "vultr_startup_script" "terrariaform-startup-script" {
@@ -54,6 +53,3 @@ resource "vultr_ssh_key" "terrariaform_ssh_key" {
   name    = "terrariaform-key"
   ssh_key = var.public_ssh_key
 }
-
-
-


### PR DESCRIPTION
This pull request introduces minor changes to improve the configuration of the `tmodloader` service in `docker-compose.yml` and cleans up the Terraform configuration in `terraform/main.tf`. The most important changes are as follows:

### Docker Compose Configuration:

* Added a `restart: unless-stopped` policy to the `tmodloader` service in `docker-compose.yml` to ensure the container restarts automatically unless explicitly stopped.

### Terraform Configuration Cleanup:

* Removed an unnecessary blank line at the end of the `resource "vultr_instance" "terrariaform-server"` block in `terraform/main.tf` to improve readability.
* Removed multiple unnecessary blank lines at the end of the `resource "vultr_ssh_key" "terrariaform_ssh_key"` block in `terraform/main.tf` for consistency and cleaner formatting.