### PR TITLE
Setup dedicated IPV4 address to game instance

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -53,3 +53,10 @@ resource "vultr_ssh_key" "terrariaform_ssh_key" {
   name    = "terrariaform-key"
   ssh_key = var.public_ssh_key
 }
+
+resource "vultr_reserved_ip" "terrariaform-reserved-ip" {
+  label = "terrariaform-reserved-ip"
+  region = var.region
+  ip_type = "v4"
+  instance_id = vultr_instance.terrariaform-server.id
+}


### PR DESCRIPTION
This pull request adds a new resource definition to the Terraform configuration for managing a reserved IP address in the Vultr cloud environment.

### Terraform configuration updates:
* Added a new `vultr_reserved_ip` resource in `terraform/main.tf` to allocate a reserved IPv4 address. This includes specifying the label, region, IP type, and associating it with the `terrariaform-server` instance.