### PR TITLE
Setup basic AWS integration

### DIFF
--- a/cloud/scripts/startup.sh
+++ b/cloud/scripts/startup.sh
@@ -27,7 +27,7 @@ mkdir -p $INSTALLATION_DIRECTORY
 
 # Cloning Terrariaform repository
 echo "Cloning Terrariaform repository..."
-git clone https://github.com/Petri-Hub/terrariaform.git $INSTALLATION_DIRECTORY
+git clone -b feat/aws-provider https://github.com/Petri-Hub/terrariaform.git $INSTALLATION_DIRECTORY
 
 # Creating .env variable (TODO: Pull from cloud)
 echo "Creating .env variable..."

--- a/cloud/scripts/startup.sh
+++ b/cloud/scripts/startup.sh
@@ -27,7 +27,7 @@ mkdir -p $INSTALLATION_DIRECTORY
 
 # Cloning Terrariaform repository
 echo "Cloning Terrariaform repository..."
-git clone -b feat/aws-provider https://github.com/Petri-Hub/terrariaform.git $INSTALLATION_DIRECTORY
+git clone https://github.com/Petri-Hub/terrariaform.git $INSTALLATION_DIRECTORY
 
 # Creating .env variable (TODO: Pull from cloud)
 echo "Creating .env variable..."

--- a/cloud/terraform/main.tf
+++ b/cloud/terraform/main.tf
@@ -1,62 +1,12 @@
 terraform {
   required_providers {
-    vultr = {
-      source = "vultr/vultr"
-      version = "2.26.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
     }
   }
 }
 
-provider "vultr" {
-  api_key = var.api_key
-}
-
-resource "vultr_instance" "terrariaform-server" {
-  label = "terrariaform-server"
-  plan = var.instance
+provider "aws" {
   region = var.region
-  os_id = var.os
-  script_id = vultr_startup_script.terrariaform-startup-script.id
-  firewall_group_id = vultr_firewall_group.terrariaform-firewall.id 
-  ssh_key_ids = [vultr_ssh_key.terrariaform_ssh_key.id]
-}
-
-resource "vultr_startup_script" "terrariaform-startup-script" {
-  name        = "terrariaform-startup-script"
-  script      = base64encode(file("../scripts/startup.sh"))
-  type        = "boot"
-}
-
-resource "vultr_firewall_group" "terrariaform-firewall" {
-  description = "Base firewall group for Terrariaform"
-}
-
-resource "vultr_firewall_rule" "terrariaform-firewall-rule" {
-  firewall_group_id = vultr_firewall_group.terrariaform-firewall.id
-  protocol          = "tcp"
-  port              = "7777"
-  subnet = "0.0.0.0"
-  subnet_size = 0
-  ip_type = "v4"
-}
-
-resource "vultr_firewall_rule" "terrariaform-firewall-rule-ssh" {
-  firewall_group_id = vultr_firewall_group.terrariaform-firewall.id
-  protocol          = "tcp"
-  port              = "22"
-  subnet = "0.0.0.0"
-  subnet_size = 0
-  ip_type = "v4"
-}
-
-resource "vultr_ssh_key" "terrariaform_ssh_key" {
-  name    = "terrariaform-key"
-  ssh_key = var.public_ssh_key
-}
-
-resource "vultr_reserved_ip" "terrariaform-reserved-ip" {
-  label = "terrariaform-reserved-ip"
-  region = var.region
-  ip_type = "v4"
-  instance_id = vultr_instance.terrariaform-server.id
 }

--- a/cloud/terraform/main.tf
+++ b/cloud/terraform/main.tf
@@ -34,6 +34,13 @@ resource "aws_vpc_security_group_ingress_rule" "terrariaform-game-allow" {
   cidr_ipv4 = "0.0.0.0/0"
 }
 
+resource "aws_vpc_security_group_egress_rule" "terrariaform-all-egress" {
+  description       = "Allow all outbound traffic"
+  security_group_id = aws_security_group.terrariaform-sg.id
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
 resource "aws_key_pair" "terrariaform-ssh-key" {
   key_name   = "terrariaform-ssh-key"
   public_key = file("~/.ssh/Projects/terrariaform/aws_instance.pub")

--- a/cloud/terraform/main.tf
+++ b/cloud/terraform/main.tf
@@ -34,6 +34,11 @@ resource "aws_vpc_security_group_ingress_rule" "terrariaform-game-allow" {
   cidr_ipv4 = "0.0.0.0/0"
 }
 
+resource "aws_key_pair" "terrariaform-ssh-key" {
+  key_name   = "terrariaform-ssh-key"
+  public_key = file("~/.ssh/Projects/terrariaform/aws_instance.pub")
+}
+
 data "aws_ami" "terrariaform-ami" {
   most_recent = true
   owners      = ["136693071363"] # Debian project owner ID
@@ -59,6 +64,7 @@ resource "aws_instance" "example" {
   instance_type = var.instance_type
   
   vpc_security_group_ids = [aws_security_group.terrariaform-sg.id]
+  key_name = aws_key_pair.terrariaform-ssh-key.key_name
 
   tags = {
     Name = "terrariaform-server"

--- a/cloud/terraform/main.tf
+++ b/cloud/terraform/main.tf
@@ -11,6 +11,29 @@ provider "aws" {
   region = var.region
 }
 
+resource "aws_security_group" "terrariaform-sg" {
+  name = "terrariaform-sg"
+  description = "Security group that enables SSH and game connections"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "terrariaform-ssh-allow" {
+  description = "Allow SSH access"
+  security_group_id = aws_security_group.terrariaform-sg.id
+  from_port         = 22
+  to_port           = 22
+  ip_protocol = "tcp"
+  cidr_ipv4 = "0.0.0.0/0"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "terrariaform-game-allow" {
+  description = "Allow game connections"
+  security_group_id = aws_security_group.terrariaform-sg.id
+  from_port         = 7777
+  to_port           = 7777
+  ip_protocol = "tcp"
+  cidr_ipv4 = "0.0.0.0/0"
+}
+
 data "aws_ami" "terrariaform-ami" {
   most_recent = true
   owners      = ["136693071363"] # Debian project owner ID
@@ -24,21 +47,19 @@ data "aws_ami" "terrariaform-ami" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
-  
+
   filter {
     name   = "root-device-type"
     values = ["ebs"]
   }
 }
 
-resource "aws_ami" "terrariaform-ami" {
-  name = "terrariaform-ami"
-}
-
 resource "aws_instance" "example" {
   ami           = data.aws_ami.terrariaform-ami.id
   instance_type = var.instance_type
   
+  vpc_security_group_ids = [aws_security_group.terrariaform-sg.id]
+
   tags = {
     Name = "terrariaform-server"
   }

--- a/cloud/terraform/main.tf
+++ b/cloud/terraform/main.tf
@@ -43,7 +43,7 @@ resource "aws_vpc_security_group_egress_rule" "terrariaform-all-egress" {
 
 resource "aws_key_pair" "terrariaform-ssh-key" {
   key_name   = "terrariaform-ssh-key"
-  public_key = file("~/.ssh/Projects/terrariaform/aws_instance.pub")
+  public_key = file(var.ssh_key_path)
 }
 
 data "aws_ami" "terrariaform-ami" {

--- a/cloud/terraform/main.tf
+++ b/cloud/terraform/main.tf
@@ -14,14 +14,17 @@ provider "aws" {
 data "aws_ami" "terrariaform-ami" {
   most_recent = true
   owners      = ["136693071363"] # Debian project owner ID
+
   filter {
     name   = "name"
     values = ["debian-12-amd64-*"]
   }
+
   filter {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+  
   filter {
     name   = "root-device-type"
     values = ["ebs"]
@@ -33,7 +36,7 @@ resource "aws_ami" "terrariaform-ami" {
 }
 
 resource "aws_instance" "example" {
-  ami           = data.aws_ami.debian12.id
+  ami           = data.aws_ami.terrariaform-ami.id
   instance_type = var.instance_type
   
   tags = {

--- a/cloud/terraform/main.tf
+++ b/cloud/terraform/main.tf
@@ -10,3 +10,36 @@ terraform {
 provider "aws" {
   region = var.region
 }
+
+data "aws_ami" "terrariaform-ami" {
+  most_recent = true
+  owners      = ["136693071363"] # Debian project owner ID
+  filter {
+    name   = "name"
+    values = ["debian-12-amd64-*"]
+  }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
+resource "aws_ami" "terrariaform-ami" {
+  name = "terrariaform-ami"
+}
+
+resource "aws_instance" "example" {
+  ami           = data.aws_ami.debian12.id
+  instance_type = var.instance_type
+  
+  tags = {
+    Name = "terrariaform-server"
+  }
+
+  user_data = file("../scripts/startup.sh")
+  user_data_replace_on_change = true
+}

--- a/cloud/terraform/variables.example.tfvars
+++ b/cloud/terraform/variables.example.tfvars
@@ -1,1 +1,2 @@
 region = 
+instance_type = 

--- a/cloud/terraform/variables.example.tfvars
+++ b/cloud/terraform/variables.example.tfvars
@@ -1,2 +1,3 @@
 region = 
 instance_type = 
+ssh_key_path =

--- a/cloud/terraform/variables.example.tfvars
+++ b/cloud/terraform/variables.example.tfvars
@@ -1,5 +1,1 @@
-api_key =
-instance =
-os =
 region = 
-public_ssh_key = 

--- a/cloud/terraform/variables.tf
+++ b/cloud/terraform/variables.tf
@@ -7,3 +7,9 @@ variable "instance_type" {
   description = "AWS instance type"
   type        = string
 }
+
+variable "ssh_key_path" {
+  description = "Path to the AWS instance SSH key"
+  type        = string
+  sensitive = true
+}

--- a/cloud/terraform/variables.tf
+++ b/cloud/terraform/variables.tf
@@ -1,26 +1,4 @@
-variable "api_key" {
-  description = "Vultr API key"
-  type        = string
-  sensitive   = true  
-}
-
 variable "region" {
-  description = "Vultr region"
+  description = "AWS region"
   type        = string
-}
-
-variable "instance" {
-  description = "Vultr instance type"
-  type        = string
-}
-
-variable "os" {
-  description = "Vultr OS ID"
-  type        = string
-}
-
-variable "public_ssh_key" {
-  description = "Public SSH key for Vultr instance"
-  type        = string
-  sensitive = true
 }

--- a/cloud/terraform/variables.tf
+++ b/cloud/terraform/variables.tf
@@ -2,3 +2,8 @@ variable "region" {
   description = "AWS region"
   type        = string
 }
+
+variable "instance_type" {
+  description = "AWS instance type"
+  type        = string
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,4 +33,3 @@ services:
   #     dockerfile: ./docker/Dockerfile 
   #   environment:
   #     - "API_HEALTH_CHECK_TEXT=${API_HEALTH_CHECK_TEXT}"
-    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,14 +23,14 @@ services:
       - "UPDATE_NOTICE=${UPDATE_NOTICE}"
     volumes:
       - "./services/server:/data"
-  api:
-    container_name: terrariaform-api
-    restart: unless-stopped
-    ports:
-      - "3000:3000"
-    build: 
-      context: ./services/api
-      dockerfile: ./docker/Dockerfile 
-    environment:
-      - "API_HEALTH_CHECK_TEXT=${API_HEALTH_CHECK_TEXT}"
+  # api:
+  #   container_name: terrariaform-api
+  #   restart: unless-stopped
+  #   ports:
+  #     - "3000:3000"
+  #   build: 
+  #     context: ./services/api
+  #     dockerfile: ./docker/Dockerfile 
+  #   environment:
+  #     - "API_HEALTH_CHECK_TEXT=${API_HEALTH_CHECK_TEXT}"
     


### PR DESCRIPTION
This pull request migrates the infrastructure from Vultr to AWS, updates the Terraform configuration accordingly, and comments out the `api` service in the `docker-compose.yml` file. The most important changes include replacing Vultr-specific resources with AWS equivalents, updating variable definitions, and disabling the API service for now.

### Migration from Vultr to AWS:

* [`cloud/terraform/main.tf`](diffhunk://#diff-a5abfa63666d1bc39f3066320c7c524d8750ceefc85fd1dce933994fad72d1bfL3-R81): Replaced Vultr resources, such as `vultr_instance`, `vultr_firewall_group`, and `vultr_ssh_key`, with AWS resources like `aws_instance`, `aws_security_group`, and `aws_key_pair`. Added new AWS-specific configurations for security groups, ingress/egress rules, and AMI selection.

* [`cloud/terraform/variables.tf`](diffhunk://#diff-aaf6f5651074f92dfd73618b35d8a9bc42b224e42b40b6804a3ec02b776b51b5L1-R12): Removed Vultr-specific variables (`api_key`, `instance`, `os`, `public_ssh_key`) and added AWS-specific variables (`instance_type`, `ssh_key_path`). Updated the description of `region` to reflect AWS usage.

* [`cloud/terraform/variables.example.tfvars`](diffhunk://#diff-4061eb60cb51d10be896991b82e2fba2ab882cdf8577700c2bab5c16b71fee1dL1-R3): Updated the example variables file to remove Vultr-specific variables and include AWS-specific ones.

### Changes to `docker-compose.yml`:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L26-R35): Commented out the `api` service configuration, effectively disabling it. This might indicate the API service is no longer needed or is temporarily paused.