### PR TITLE
Add reserved IP address to game server

### DIFF
--- a/cloud/terraform/main.tf
+++ b/cloud/terraform/main.tf
@@ -13,29 +13,36 @@ provider "aws" {
 
 resource "aws_eip" "terrariaform_elastic_ip" {
   instance = aws_instance.terrariaform_server.id
+  tags = {
+    Name = "terrariaform-elastic-ip"
+  }
 }
 
 resource "aws_security_group" "terrariaform_sg" {
-  name = "terrariaform-sg"
+  name        = "terrariaform-sg"
   description = "Security group that enables SSH and game connections"
+
+  tags = {
+    Name = "terrariaform-sg"
+  }
 }
 
 resource "aws_vpc_security_group_ingress_rule" "terrariaform_ssh_allow" {
-  description = "Allow SSH access"
+  description       = "Allow SSH access"
   security_group_id = aws_security_group.terrariaform_sg.id
   from_port         = 22
   to_port           = 22
-  ip_protocol = "tcp"
-  cidr_ipv4 = "0.0.0.0/0"
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
 }
 
 resource "aws_vpc_security_group_ingress_rule" "terrariaform_game_allow" {
-  description = "Allow game connections"
+  description       = "Allow game connections"
   security_group_id = aws_security_group.terrariaform_sg.id
   from_port         = 7777
   to_port           = 7777
-  ip_protocol = "tcp"
-  cidr_ipv4 = "0.0.0.0/0"
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
 }
 
 resource "aws_vpc_security_group_egress_rule" "terrariaform_all_egress" {
@@ -73,14 +80,14 @@ data "aws_ami" "terrariaform_ami" {
 resource "aws_instance" "terrariaform_server" {
   ami           = data.aws_ami.terrariaform_ami.id
   instance_type = var.instance_type
-  
+
   vpc_security_group_ids = [aws_security_group.terrariaform_sg.id]
-  key_name = aws_key_pair.terrariaform_ssh_key.key_name
+  key_name               = aws_key_pair.terrariaform_ssh_key.key_name
 
   tags = {
     Name = "terrariaform-server"
   }
 
-  user_data = file("../scripts/startup.sh")
+  user_data                   = file("../scripts/startup.sh")
   user_data_replace_on_change = true
 }

--- a/cloud/terraform/main.tf
+++ b/cloud/terraform/main.tf
@@ -11,6 +11,10 @@ provider "aws" {
   region = var.region
 }
 
+resource "aws_eip" "terrariaform-elastic-ip" {
+  instance = aws_instance.example.id
+}
+
 resource "aws_security_group" "terrariaform-sg" {
   name = "terrariaform-sg"
   description = "Security group that enables SSH and game connections"
@@ -66,7 +70,7 @@ data "aws_ami" "terrariaform-ami" {
   }
 }
 
-resource "aws_instance" "example" {
+resource "aws_instance" "terrariaform-server" {
   ami           = data.aws_ami.terrariaform-ami.id
   instance_type = var.instance_type
   

--- a/cloud/terraform/main.tf
+++ b/cloud/terraform/main.tf
@@ -11,46 +11,46 @@ provider "aws" {
   region = var.region
 }
 
-resource "aws_eip" "terrariaform-elastic-ip" {
-  instance = aws_instance.example.id
+resource "aws_eip" "terrariaform_elastic_ip" {
+  instance = aws_instance.terrariaform_server.id
 }
 
-resource "aws_security_group" "terrariaform-sg" {
+resource "aws_security_group" "terrariaform_sg" {
   name = "terrariaform-sg"
   description = "Security group that enables SSH and game connections"
 }
 
-resource "aws_vpc_security_group_ingress_rule" "terrariaform-ssh-allow" {
+resource "aws_vpc_security_group_ingress_rule" "terrariaform_ssh_allow" {
   description = "Allow SSH access"
-  security_group_id = aws_security_group.terrariaform-sg.id
+  security_group_id = aws_security_group.terrariaform_sg.id
   from_port         = 22
   to_port           = 22
   ip_protocol = "tcp"
   cidr_ipv4 = "0.0.0.0/0"
 }
 
-resource "aws_vpc_security_group_ingress_rule" "terrariaform-game-allow" {
+resource "aws_vpc_security_group_ingress_rule" "terrariaform_game_allow" {
   description = "Allow game connections"
-  security_group_id = aws_security_group.terrariaform-sg.id
+  security_group_id = aws_security_group.terrariaform_sg.id
   from_port         = 7777
   to_port           = 7777
   ip_protocol = "tcp"
   cidr_ipv4 = "0.0.0.0/0"
 }
 
-resource "aws_vpc_security_group_egress_rule" "terrariaform-all-egress" {
+resource "aws_vpc_security_group_egress_rule" "terrariaform_all_egress" {
   description       = "Allow all outbound traffic"
-  security_group_id = aws_security_group.terrariaform-sg.id
+  security_group_id = aws_security_group.terrariaform_sg.id
   ip_protocol       = "-1"
   cidr_ipv4         = "0.0.0.0/0"
 }
 
-resource "aws_key_pair" "terrariaform-ssh-key" {
+resource "aws_key_pair" "terrariaform_ssh_key" {
   key_name   = "terrariaform-ssh-key"
   public_key = file(var.ssh_key_path)
 }
 
-data "aws_ami" "terrariaform-ami" {
+data "aws_ami" "terrariaform_ami" {
   most_recent = true
   owners      = ["136693071363"] # Debian project owner ID
 
@@ -70,12 +70,12 @@ data "aws_ami" "terrariaform-ami" {
   }
 }
 
-resource "aws_instance" "terrariaform-server" {
-  ami           = data.aws_ami.terrariaform-ami.id
+resource "aws_instance" "terrariaform_server" {
+  ami           = data.aws_ami.terrariaform_ami.id
   instance_type = var.instance_type
   
-  vpc_security_group_ids = [aws_security_group.terrariaform-sg.id]
-  key_name = aws_key_pair.terrariaform-ssh-key.key_name
+  vpc_security_group_ids = [aws_security_group.terrariaform_sg.id]
+  key_name = aws_key_pair.terrariaform_ssh_key.key_name
 
   tags = {
     Name = "terrariaform-server"

--- a/cloud/terraform/outputs.tf
+++ b/cloud/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "server_ip" {
+    description = "Server IP address for game connections"
+    value = aws_eip.terrariaform_elastic_ip.public_ip
+}


### PR DESCRIPTION
This pull request introduces several updates to the Terraform configuration for provisioning AWS resources, focusing on improving naming consistency, adding an Elastic IP resource, and defining an output for the server's public IP. Below are the most important changes grouped by theme:

### Resource additions and outputs:
* Added a new `aws_eip` resource (`terrariaform_elastic_ip`) to associate an Elastic IP with the game server instance.
* Defined a new output `server_ip` in `outputs.tf` to expose the public IP address of the server for game connections.

### Naming consistency:
* Updated resource names to use consistent snake_case formatting (e.g., `terrariaform-sg` → `terrariaform_sg`, `terrariaform-ssh-key` → `terrariaform_ssh_key`). [[1]](diffhunk://#diff-a5abfa63666d1bc39f3066320c7c524d8750ceefc85fd1dce933994fad72d1bfL14-R60) [[2]](diffhunk://#diff-a5abfa63666d1bc39f3066320c7c524d8750ceefc85fd1dce933994fad72d1bfL69-R85)

### Resource updates:
* Renamed the EC2 instance resource from `example` to `terrariaform_server` for clarity and alignment with the project naming convention.