### PR TITLE
Change the target branch when downloading the project in the 'startup.sh' script

### DIFF
--- a/cloud/scripts/startup.sh
+++ b/cloud/scripts/startup.sh
@@ -59,7 +59,7 @@ systemctl start docker
 
 # Cloning Terrariaform repository
 echo "Cloning Terrariaform repository..."
-git clone -b feat/ebs-volume https://github.com/Petri-Hub/terrariaform.git $INSTALLATION_DIRECTORY
+git clone https://github.com/Petri-Hub/terrariaform.git $INSTALLATION_DIRECTORY
 
 # Creating .env variable (TODO: Pull from cloud)
 echo "Creating .env variable..."


### PR DESCRIPTION
This pull request includes a small change to the `cloud/scripts/startup.sh` file. The change removes the specific branch (`feat/ebs-volume`) from the `git clone` command, defaulting the clone operation to the repository's main branch.