### PR TITLE
Add Vercel provider to point a subdomain to game server

### DIFF
--- a/cloud/terraform/main.tf
+++ b/cloud/terraform/main.tf
@@ -94,3 +94,12 @@ resource "aws_volume_attachment" "terrariaform_data_attach" {
   instance_id = aws_instance.terrariaform_server.id
   force_detach = true
 }
+
+# Vercel DNS Configuration
+resource "vercel_dns_record" "terraria_subdomain" {
+  domain = var.vercel_domain_name
+  type   = "A"
+  name   = var.vercel_terraria_subdomain
+  value  = aws_eip.terrariaform_elastic_ip.public_ip
+  ttl    = 60
+}

--- a/cloud/terraform/main.tf
+++ b/cloud/terraform/main.tf
@@ -41,7 +41,7 @@ resource "aws_vpc_security_group_egress_rule" "terrariaform_all_egress" {
 
 resource "aws_key_pair" "terrariaform_ssh_key" {
   key_name   = "terrariaform-ssh-key"
-  public_key = file(var.ssh_key_path)
+  public_key = file(var.aws_ssh_key_path)
 }
 
 data "aws_ami" "terrariaform_ami" {
@@ -66,7 +66,7 @@ data "aws_ami" "terrariaform_ami" {
 
 resource "aws_instance" "terrariaform_server" {
   ami           = data.aws_ami.terrariaform_ami.id
-  instance_type = var.instance_type
+  instance_type = var.aws_instance_type
 
   vpc_security_group_ids = [aws_security_group.terrariaform_sg.id]
   key_name               = aws_key_pair.terrariaform_ssh_key.key_name

--- a/cloud/terraform/main.tf
+++ b/cloud/terraform/main.tf
@@ -95,7 +95,6 @@ resource "aws_volume_attachment" "terrariaform_data_attach" {
   force_detach = true
 }
 
-# Vercel DNS Configuration
 resource "vercel_dns_record" "terraria_subdomain" {
   domain = var.vercel_domain_name
   type   = "A"

--- a/cloud/terraform/outputs.tf
+++ b/cloud/terraform/outputs.tf
@@ -2,3 +2,13 @@ output "server_ip" {
     description = "Server IP address for game connections"
     value = aws_eip.terrariaform_elastic_ip.public_ip
 }
+
+output "terraria_subdomain" {
+    description = "Subdomain for the Terraria server"
+    value = "${var.vercel_terraria_subdomain}.${var.vercel_domain_name}"
+}
+
+output "dns_record_id" {
+    description = "Vercel DNS record ID for the terraria subdomain"
+    value = vercel_dns_record.terraria_subdomain.id
+}

--- a/cloud/terraform/providers.tf
+++ b/cloud/terraform/providers.tf
@@ -4,9 +4,17 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    vercel = {
+      source  = "vercel/vercel"
+      version = "~> 2.0"
+    }
   }
 }
 
 provider "aws" {
   region = var.region
+}
+
+provider "vercel" {
+  api_token = var.vercel_api_token
 }

--- a/cloud/terraform/providers.tf
+++ b/cloud/terraform/providers.tf
@@ -12,7 +12,7 @@ terraform {
 }
 
 provider "aws" {
-  region = var.region
+  region = var.aws_region
 }
 
 provider "vercel" {

--- a/cloud/terraform/providers.tf
+++ b/cloud/terraform/providers.tf
@@ -17,4 +17,5 @@ provider "aws" {
 
 provider "vercel" {
   api_token = var.vercel_api_token
+  team = var.vercel_team_id
 }

--- a/cloud/terraform/variables.example.tfvars
+++ b/cloud/terraform/variables.example.tfvars
@@ -2,3 +2,7 @@ aws_region =
 aws_instance_type = 
 aws_ssh_key_path =
 vercel_api_token =
+vercel_team_id =
+vercel_team_id =
+vercel_domain_name =
+vercel_terraria_subdomain =

--- a/cloud/terraform/variables.example.tfvars
+++ b/cloud/terraform/variables.example.tfvars
@@ -1,4 +1,4 @@
-region = 
-instance_type = 
-ssh_key_path =
-vercel_api_token = 
+aws_region = 
+aws_instance_type = 
+aws_ssh_key_path =
+vercel_api_token =

--- a/cloud/terraform/variables.example.tfvars
+++ b/cloud/terraform/variables.example.tfvars
@@ -1,3 +1,4 @@
 region = 
 instance_type = 
 ssh_key_path =
+vercel_api_token = 

--- a/cloud/terraform/variables.tf
+++ b/cloud/terraform/variables.tf
@@ -19,3 +19,15 @@ variable "vercel_api_token" {
   type        = string
   sensitive = true
 }
+
+variable "vercel_domain_name" {
+  description = "The domain name managed by Vercel"
+  type        = string
+  default     = "petri.codes"
+}
+
+variable "vercel_terraria_subdomain" {
+  description = "The subdomain for the Terraria server"
+  type        = string
+  default     = "terraria"
+}

--- a/cloud/terraform/variables.tf
+++ b/cloud/terraform/variables.tf
@@ -1,14 +1,14 @@
-variable "region" {
+variable "aws_region" {
   description = "AWS region"
   type        = string
 }
 
-variable "instance_type" {
+variable "aws_instance_type" {
   description = "AWS instance type"
   type        = string
 }
 
-variable "ssh_key_path" {
+variable "aws_ssh_key_path" {
   description = "Path to the AWS instance SSH key"
   type        = string
   sensitive = true

--- a/cloud/terraform/variables.tf
+++ b/cloud/terraform/variables.tf
@@ -13,3 +13,9 @@ variable "ssh_key_path" {
   type        = string
   sensitive = true
 }
+
+variable "vercel_api_token" {
+  description = "Vercel API token"
+  type        = string
+  sensitive = true
+}

--- a/cloud/terraform/variables.tf
+++ b/cloud/terraform/variables.tf
@@ -20,6 +20,11 @@ variable "vercel_api_token" {
   sensitive = true
 }
 
+variable "vercel_team_id" {
+  description = "Vercel team ID for managing the domain"
+  type        = string
+}
+
 variable "vercel_domain_name" {
   description = "The domain name managed by Vercel"
   type        = string


### PR DESCRIPTION
This pull request introduces changes to the Terraform configuration to enhance AWS resource management and integrate Vercel for DNS management. Key updates include renaming AWS-related variables for clarity, adding support for Vercel DNS records, and updating outputs to include the new subdomain information.

### AWS-related updates:
* Renamed variables in `cloud/terraform/variables.tf` for consistency (`region` → `aws_region`, `instance_type` → `aws_instance_type`, `ssh_key_path` → `aws_ssh_key_path`) and updated their usage across the configuration (`cloud/terraform/main.tf`, `cloud/terraform/providers.tf`). [[1]](diffhunk://#diff-a5abfa63666d1bc39f3066320c7c524d8750ceefc85fd1dce933994fad72d1bfL44-R44) [[2]](diffhunk://#diff-a5abfa63666d1bc39f3066320c7c524d8750ceefc85fd1dce933994fad72d1bfL69-R69) [[3]](diffhunk://#diff-4955cc97cdb34fdeda6c3b98b24cf78c4779734292a8e55beb109a85915cbf6cR7-R20) [[4]](diffhunk://#diff-aaf6f5651074f92dfd73618b35d8a9bc42b224e42b40b6804a3ec02b776b51b5L1-R38)

### Vercel integration:
* Added a `vercel` provider to `cloud/terraform/providers.tf` for managing DNS records.
* Created a new `vercel_dns_record` resource in `cloud/terraform/main.tf` to define a subdomain for the Terraria server.
* Added new variables for Vercel configuration (`vercel_api_token`, `vercel_team_id`, `vercel_domain_name`, `vercel_terraria_subdomain`) in `cloud/terraform/variables.tf` and updated the example variables file (`cloud/terraform/variables.example.tfvars`). [[1]](diffhunk://#diff-aaf6f5651074f92dfd73618b35d8a9bc42b224e42b40b6804a3ec02b776b51b5L1-R38) [[2]](diffhunk://#diff-4061eb60cb51d10be896991b82e2fba2ab882cdf8577700c2bab5c16b71fee1dL1-R8)

### Outputs:
* Added outputs for the Terraria subdomain and the Vercel DNS record ID in `cloud/terraform/outputs.tf`.