### PR TITLE
Remove default values from Terraform example variable files

### DIFF
--- a/cloud/terraform/variables.tf
+++ b/cloud/terraform/variables.tf
@@ -28,11 +28,9 @@ variable "vercel_team_id" {
 variable "vercel_domain_name" {
   description = "The domain name managed by Vercel"
   type        = string
-  default     = "petri.codes"
 }
 
 variable "vercel_terraria_subdomain" {
   description = "The subdomain for the Terraria server"
   type        = string
-  default     = "terraria"
 }


### PR DESCRIPTION
This pull request removes the default values for two Terraform variables in the `cloud/terraform/variables.tf` file. These changes ensure that the values must be explicitly provided, improving configurability and reducing assumptions.

* **Terraform variable updates:**
  * Removed the default value `"petri.codes"` for the `vercel_domain_name` variable.
  * Removed the default value `"terraria"` for the `vercel_terraria_subdomain` variable.