### PR TITLE
Allow API calls on port 3000

### DIFF
--- a/cloud/terraform/main.tf
+++ b/cloud/terraform/main.tf
@@ -32,6 +32,15 @@ resource "aws_vpc_security_group_ingress_rule" "terrariaform_game_allow" {
   cidr_ipv4         = "0.0.0.0/0"
 }
 
+resource "aws_vpc_security_group_ingress_rule" "terrariaform_api_allow" {
+  description       = "Allow API requests"
+  security_group_id = aws_security_group.terrariaform_sg.id
+  from_port         = 3000
+  to_port           = 3000
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
 resource "aws_vpc_security_group_egress_rule" "terrariaform_all_egress" {
   description       = "Allow all outbound traffic"
   security_group_id = aws_security_group.terrariaform_sg.id


### PR DESCRIPTION
This pull request adds a new security group ingress rule to allow API requests in the Terraform configuration.

* **New Ingress Rule Added**:
  - `aws_vpc_security_group_ingress_rule` for `terrariaform_api_allow` was added to permit inbound traffic on port 3000 over TCP from any IPv4 address (`0.0.0.0/0`). This is intended to allow API requests. (`[cloud/terraform/main.tfR35-R43](diffhunk://#diff-a5abfa63666d1bc39f3066320c7c524d8750ceefc85fd1dce933994fad72d1bfR35-R43)`)