### PR TITLE
feat: prevent EBS destruction without turning off security flag

### DIFF
--- a/cloud/terraform/main.tf
+++ b/cloud/terraform/main.tf
@@ -95,6 +95,8 @@ resource "aws_ebs_volume" "terrariaform_data" {
   size              = 6
   type              = "gp3"
   
+  # Prevents accidental destruction of the volume.
+  # This would erase all game data.
   lifecycle {
     prevent_destroy = var.secure_destruction
   }

--- a/cloud/terraform/main.tf
+++ b/cloud/terraform/main.tf
@@ -94,8 +94,14 @@ resource "aws_ebs_volume" "terrariaform_data" {
   availability_zone = aws_instance.terrariaform_server.availability_zone
   size              = 6
   type              = "gp3"
+  
+  lifecycle {
+    prevent_destroy = var.secure_destruction
+  }
+  
   tags = {
     Name = "terrariaform-volume"
+    Type = "GameData"
   }
 }
 

--- a/cloud/terraform/variables.example.tfvars
+++ b/cloud/terraform/variables.example.tfvars
@@ -6,3 +6,4 @@ vercel_team_id =
 vercel_team_id =
 vercel_domain_name =
 vercel_terraria_subdomain =
+secure_destruction =

--- a/cloud/terraform/variables.tf
+++ b/cloud/terraform/variables.tf
@@ -40,3 +40,9 @@ variable "env_file_path" {
   type        = string
   default     = "../../.env"
 }
+
+variable "secure_destruction" {
+  description = "Set to false to allow destruction of persistent EBS volumes. Use with caution!"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
This pull request introduces a new `secure_destruction` variable to enhance the safety of managing persistent EBS volumes in Terraform. It also adds a new tag to the EBS volume resource for better categorization. Below are the key changes grouped by theme:

### Enhancements to EBS Volume Configuration:
* Added a `lifecycle` block to the `aws_ebs_volume` resource to prevent destruction when `secure_destruction` is set to `true`. This helps safeguard persistent data. (`cloud/terraform/main.tf`, [cloud/terraform/main.tfR97-R104](diffhunk://#diff-a5abfa63666d1bc39f3066320c7c524d8750ceefc85fd1dce933994fad72d1bfR97-R104))
* Added a new `Type = "GameData"` tag to the `aws_ebs_volume` resource for improved resource categorization. (`cloud/terraform/main.tf`, [cloud/terraform/main.tfR97-R104](diffhunk://#diff-a5abfa63666d1bc39f3066320c7c524d8750ceefc85fd1dce933994fad72d1bfR97-R104))

### Variable Management:
* Introduced a new `secure_destruction` variable in `variables.tf` with a default value of `true`, allowing users to control whether persistent EBS volumes can be destroyed. (`cloud/terraform/variables.tf`, [cloud/terraform/variables.tfR43-R48](diffhunk://#diff-aaf6f5651074f92dfd73618b35d8a9bc42b224e42b40b6804a3ec02b776b51b5R43-R48))
* Added `secure_destruction` to the example variables file (`variables.example.tfvars`) for better documentation and usability. (`cloud/terraform/variables.example.tfvars`, [cloud/terraform/variables.example.tfvarsR9](diffhunk://#diff-4061eb60cb51d10be896991b82e2fba2ab882cdf8577700c2bab5c16b71fee1dR9))